### PR TITLE
[bug]: stop rendering before project is ready

### DIFF
--- a/src/views/ProposalDetail.vue
+++ b/src/views/ProposalDetail.vue
@@ -1,9 +1,6 @@
 <template>
   <section class="proposal-detail">
-    <div
-      class="loading-container container"
-      v-if="!$store.getters.projectDetail._id"
-    >
+    <div class="loading-container container" v-if="!isProjectReady">
       <div class="loading">
         <div class="line"></div>
         <div class="line"></div>
@@ -58,6 +55,12 @@ export default {
       isVersionDetailLightboxOpen: false,
       openVersionIndex: 0
     };
+  },
+  computed: {
+    isProjectReady() {
+      const detail = this.$store.getters.projectDetail;
+      return detail && detail._id && detail.versions.length > 0;
+    }
   },
   methods: {
     openVersionDetailLightboxOpen(index) {


### PR DESCRIPTION
目前在建立第一個版本時，因為 versions: [] 還是空的，會導致 `ProposalDetail` 出現錯誤，讀不到 `latestVersion`。

我先加了折衷解，確定 versions.length > 0 後才會顯示， @UnaLai 可以看看有沒有更好的解法～